### PR TITLE
Align stats card typography with RPD gold tokens

### DIFF
--- a/invoice-dashboard/src/components/dashboard/stats-cards.tsx
+++ b/invoice-dashboard/src/components/dashboard/stats-cards.tsx
@@ -84,22 +84,34 @@ export function StatsCards({ stats }: StatsCardsProps) {
           primary: {
             background: 'linear-gradient(135deg, oklch(0.25 0.08 240 / 0.1), oklch(0.35 0.08 240 / 0.05))',
             borderColor: 'oklch(0.25 0.08 240 / 0.2)',
-            iconBg: 'linear-gradient(135deg, oklch(0.25 0.08 240), oklch(0.35 0.08 240))'
+            iconBg: 'linear-gradient(135deg, oklch(0.25 0.08 240), oklch(0.35 0.08 240))',
+            titleColor: 'hsl(var(--rpd-gold-secondary))',
+            valueColor: 'hsl(var(--rpd-gold-primary))',
+            metaColor: 'hsla(var(--rpd-gold-primary) / 0.8)'
           },
           success: {
             background: 'linear-gradient(135deg, oklch(0.65 0.12 80 / 0.1), oklch(0.75 0.12 80 / 0.05))',
-            borderColor: 'oklch(0.65 0.12 80 / 0.2)', 
-            iconBg: 'linear-gradient(135deg, oklch(0.65 0.12 80), oklch(0.75 0.12 80))'
+            borderColor: 'oklch(0.65 0.12 80 / 0.2)',
+            iconBg: 'linear-gradient(135deg, oklch(0.65 0.12 80), oklch(0.75 0.12 80))',
+            titleColor: 'hsl(var(--rpd-gold-secondary))',
+            valueColor: 'hsl(var(--rpd-gold-primary))',
+            metaColor: 'hsla(var(--rpd-gold-primary) / 0.8)'
           },
           warning: {
             background: 'linear-gradient(135deg, oklch(0.70 0.18 50 / 0.1), oklch(0.80 0.18 50 / 0.05))',
             borderColor: 'oklch(0.70 0.18 50 / 0.2)',
-            iconBg: 'linear-gradient(135deg, oklch(0.70 0.18 50), oklch(0.80 0.18 50))'
+            iconBg: 'linear-gradient(135deg, oklch(0.70 0.18 50), oklch(0.80 0.18 50))',
+            titleColor: 'hsl(var(--rpd-gold-secondary))',
+            valueColor: 'hsl(var(--rpd-gold-primary))',
+            metaColor: 'hsla(var(--rpd-gold-primary) / 0.8)'
           },
           danger: {
             background: 'linear-gradient(135deg, oklch(0.60 0.20 20 / 0.1), oklch(0.70 0.20 20 / 0.05))',
             borderColor: 'oklch(0.60 0.20 20 / 0.2)',
-            iconBg: 'linear-gradient(135deg, oklch(0.60 0.20 20), oklch(0.70 0.20 20))'
+            iconBg: 'linear-gradient(135deg, oklch(0.60 0.20 20), oklch(0.70 0.20 20))',
+            titleColor: 'hsl(var(--rpd-gold-secondary))',
+            valueColor: 'hsl(var(--rpd-gold-primary))',
+            metaColor: 'hsla(var(--rpd-gold-primary) / 0.8)'
           }
         };
         
@@ -119,7 +131,7 @@ export function StatsCards({ stats }: StatsCardsProps) {
             <div className="absolute inset-0 scale-0 bg-white/10 dark:bg-black/10 rounded-lg group-active:scale-100 transition-transform duration-200 ease-out" />
             
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 relative z-10">
-              <CardTitle className="text-sm font-medium" style={{color: 'oklch(0.25 0.08 240)'}}>
+              <CardTitle className="text-sm font-medium" style={{ color: cardStyle[card.type].titleColor }}>
                 {card.title}
               </CardTitle>
               <div className="p-2 rounded-lg shadow-md group-hover:scale-110 transition-all duration-300 ease-out floating"
@@ -131,24 +143,36 @@ export function StatsCards({ stats }: StatsCardsProps) {
             </CardHeader>
             <CardContent className="relative z-10">
               <div className="space-y-3">
-                <div className="text-2xl font-bold group-hover:scale-105 transition-transform duration-300 ease-out" style={{color: 'oklch(0.1 0.1 240)'}}>
+                <div
+                  className="text-2xl font-bold group-hover:scale-105 transition-transform duration-300 ease-out"
+                  style={{ color: cardStyle[card.type].valueColor }}
+                >
                   {card.value}
                 </div>
-                
+
                 <div className="flex items-center space-x-2">
-                  <Badge 
-                    variant="outline" 
+                  <Badge
+                    variant="outline"
                     className="flex items-center space-x-1 px-2 py-1 group-hover:pulse-glow transition-all duration-300 border-slate-200 hover:bg-slate-50"
                     style={{
-                      color: card.trendUp ? 'oklch(0.2 0.08 240)' : 'oklch(0.4 0.06 240)',
+                      color: card.trendUp ? cardStyle[card.type].valueColor : cardStyle[card.type].metaColor,
                       backgroundColor: 'oklch(0.95 0.02 240)',
                       borderColor: 'oklch(0.85 0.04 240)'
                     }}
                   >
                     <TrendIcon className={`h-3 w-3 transition-all duration-300 ${card.trendUp ? 'group-hover:animate-bounce' : 'group-hover:animate-pulse'}`} />
-                    <span className="text-xs font-medium">{card.trend}</span>
+                    <span
+                      className="text-xs font-medium"
+                      style={{
+                        color: card.trendUp
+                          ? cardStyle[card.type].valueColor
+                          : cardStyle[card.type].metaColor,
+                      }}
+                    >
+                      {card.trend}
+                    </span>
                   </Badge>
-                  <span className="text-xs" style={{color: 'oklch(0.35 0.04 240)'}}>
+                  <span className="text-xs" style={{ color: cardStyle[card.type].metaColor }}>
                     vs last month
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- extend each stats card style definition with brand-aware title, value, and meta colors
- apply the new brand tokens to the card title, primary value, and supporting trend/meta text

## Testing
- npm run lint *(fails: existing lint violations across generated Prisma runtime and legacy scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb97a4e90832f9e6684d03a1d0697