### PR TITLE
fix: unclipped invoice date picker

### DIFF
--- a/invoice-dashboard/src/app/globals.css
+++ b/invoice-dashboard/src/app/globals.css
@@ -244,3 +244,22 @@
 .react-datepicker__day--outside-month {
   @apply text-slate-400 dark:text-slate-600;
 }
+
+.calendar-surface {
+  overflow: visible;
+  padding: 0.25rem 0.5rem 0.5rem;
+}
+
+.invoice-date-picker.react-datepicker {
+  width: 100%;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  padding: 0.25rem 0.5rem 0.5rem;
+  box-sizing: border-box;
+}
+
+.invoice-date-picker .react-datepicker__week {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}

--- a/invoice-dashboard/src/components/invoices/invoice-filters.tsx
+++ b/invoice-dashboard/src/components/invoices/invoice-filters.tsx
@@ -254,14 +254,17 @@ export function InvoiceFilters({ invoices, onFilterChange }: InvoiceFiltersProps
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0" align="start">
-                  <DatePicker
-                    selected={startDate}
-                    onChange={(date) => setStartDate(date)}
-                    inline
-                    showYearDropdown
-                    showMonthDropdown
-                    dropdownMode="select"
-                  />
+                  <div className="calendar-surface">
+                    <DatePicker
+                      selected={startDate}
+                      onChange={(date) => setStartDate(date)}
+                      inline
+                      showYearDropdown
+                      showMonthDropdown
+                      dropdownMode="select"
+                      calendarClassName="invoice-date-picker"
+                    />
+                  </div>
                 </PopoverContent>
               </Popover>
             </div>
@@ -276,15 +279,18 @@ export function InvoiceFilters({ invoices, onFilterChange }: InvoiceFiltersProps
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0" align="start">
-                  <DatePicker
-                    selected={endDate}
-                    onChange={(date) => setEndDate(date)}
-                    inline
-                    showYearDropdown
-                    showMonthDropdown
-                    dropdownMode="select"
-                    minDate={startDate || undefined}
-                  />
+                  <div className="calendar-surface">
+                    <DatePicker
+                      selected={endDate}
+                      onChange={(date) => setEndDate(date)}
+                      inline
+                      showYearDropdown
+                      showMonthDropdown
+                      dropdownMode="select"
+                      minDate={startDate || undefined}
+                      calendarClassName="invoice-date-picker"
+                    />
+                  </div>
                 </PopoverContent>
               </Popover>
             </div>


### PR DESCRIPTION
## Summary
- wrap the invoice filter popovers in a calendar-surface container and apply the invoice-date-picker class to the inline pickers
- update the global stylesheet with calendar-surface padding, invoice-date-picker sizing, and grid-based week rows to prevent Saturday clipping

## Testing
- npm run lint *(fails: existing lint violations in generated prisma runtime and various legacy scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb97cb620832faf4e41d992158815