### PR TITLE
chore: use webpack build for vercel deployments

### DIFF
--- a/Documents/todo/invoice-dashboard/vercel.json
+++ b/Documents/todo/invoice-dashboard/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "TURBOPACK=0 npm run build"
+  "buildCommand": "npm run build:webpack"
 }

--- a/Documents/todo/vercel.json
+++ b/Documents/todo/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "framework": "nextjs",
   "rootDirectory": "invoice-dashboard",
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run build:webpack",
   "installCommand": "npm ci --no-optional",
   "cleanUrls": true,
   "env": {

--- a/invoice-dashboard/package.json
+++ b/invoice-dashboard/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
+    "build:webpack": "next build",
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "analyze": "ANALYZE=true npm run build"
+    "analyze": "ANALYZE=true npm run build:webpack"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- update the Next.js build script to use the default webpack pipeline and add a dedicated `build:webpack` command
- point the Vercel deployment configuration at the webpack build script so deployments no longer rely on Turbopack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce1eb8e154832fa391fe345ae2a18d