### PR TITLE
Refine webpack performance configuration

### DIFF
--- a/invoice-dashboard/next.config.ts
+++ b/invoice-dashboard/next.config.ts
@@ -63,13 +63,12 @@ const nextConfig: NextConfig = {
               priority: 10,
             }
           }
-        },
-        // Performance hints
-        performance: {
-          maxAssetSize: 250000,
-          maxEntrypointSize: 400000,
-          hints: 'warning'
         }
+      };
+      config.performance = {
+        maxAssetSize: 250000,
+        maxEntrypointSize: 400000,
+        hints: 'warning'
       };
     }
     


### PR DESCRIPTION
## Summary
- move the webpack performance budget out of the optimization object to avoid schema errors
- assign the performance budget on the top-level webpack config with the existing limits

## Testing
- npm run build:webpack *(fails: unable to download Google Fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce255f4a5c832f94ec8bdba60539f6