### PR TITLE
Run prisma generate automatically

### DIFF
--- a/invoice-dashboard/package.json
+++ b/invoice-dashboard/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "analyze": "ANALYZE=true npm run build:webpack"
+    "analyze": "ANALYZE=true npm run build:webpack",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- configure the project to run `prisma generate` during npm install to ensure the client is generated automatically

## Testing
- `npx prisma generate`
- `npm run build` *(fails: Next.js could not download Google Fonts in the offline CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce279aaff0832f89c2fe736b148ff3