### PR TITLE
Use default Prisma client output location

### DIFF
--- a/invoice-dashboard/.gitignore
+++ b/invoice-dashboard/.gitignore
@@ -40,4 +40,3 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-/src/generated/prisma

--- a/invoice-dashboard/prisma/schema.prisma
+++ b/invoice-dashboard/prisma/schema.prisma
@@ -3,7 +3,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../src/generated/prisma"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- remove the custom Prisma Client output path override
- delete the redundant generated client folder and clean up the ignore list

## Testing
- npx prisma generate
- npm run build *(fails: Next.js cannot fetch Inter/JetBrains Mono from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce29c278e0832f8c61ca0b0b35628e